### PR TITLE
test submodules get with https cloned parent when ssh-git not setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Container image that runs your code
-FROM ghcr.io/courtois-neuromod/datalad:alpine
+FROM ghcr.io/courtois-neuromod/datalad:main
 
 ADD . /actions
-WORKDIR /actions
+WORKDIR /work
+RUN python -m pip install --no-cache-dir pytest-order
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
-ENTRYPOINT ["pytest", "-s", "-o", "log_cli=true", "/actions/tests"]
+ENTRYPOINT ["pytest", "-s", "--log-cli-level", "WARN", "/actions/tests"]

--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -13,12 +13,16 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope="session", autouse=True)
 def setup_git(
         username=os.environ['GIT_USERNAME'],
-        email=os.environ['GIT_EMAIL']):
+        email=os.environ['GIT_EMAIL']
+    ):
 
     config = ConfigManager()
     config.set('user.name', username, scope='global')
     config.set('user.email', email, scope='global')
+    config.set('annex.security.allowed-ip-addresses', '10.10.10.20', scope='global')
 
+@pytest.fixture(scope="session")
+def setup_ssh():
     os.makedirs(os.path.join(os.environ['HOME'],'.ssh'), mode=700, exist_ok=True)
 
     subprocess.call(["sh", '-c', f"ssh-keyscan -H github.com | install -m 600 /dev/stdin /{os.environ['HOME']}/.ssh/known_hosts"])
@@ -32,11 +36,21 @@ def setup_git(
 
 
 @pytest.fixture(scope="session")
-def dataset(setup_git):
-    ds = install(f"git@github.com:{os.environ['GITHUB_REPOSITORY']}.git")
+def dataset(setup_git, setup_ssh):
+    yield from install_ds(protocol='ssh')
+
+def install_ds(protocol='ssh'):
+    url = f"git@github.com:{os.environ['GITHUB_REPOSITORY']}.git"
+    if protocol=='https':
+        url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}.git"
+    ds = install(path=f"ds_{protocol}", source=url)
     ds.repo.fetch('origin', os.environ['GITHUB_REF'])
     commitish = GIT_ANNEX_TEST_BRANCH if 'git-annex' in os.environ['GITHUB_REF_NAME'] else os.environ['GITHUB_SHA']
     logger.info(f"checking out {commitish}")
     ds.repo.checkout(commitish)
     yield ds
-    #ds.uninstall(check=False, recursive=True) #teardown
+    ds.drop(reckless='kill', recursive=True) #teardown
+
+@pytest.fixture(scope="function")
+def dataset_https():
+    yield from install_ds(protocol="https")

--- a/tests/deploy/test_deploy.py
+++ b/tests/deploy/test_deploy.py
@@ -5,6 +5,15 @@ from . import utils
 import logging
 logger = logging.getLogger(__name__)
 
+# check for https://github.com/datalad/datalad/issues/7604
+# has to run first, before `setup_ssh`
+@pytest.mark.order(1)
+def test_get_submodules_https_parent(dataset_https):
+    dataset_https.get('.', recursive=True, recursion_limit=1, get_data=False)
+
+def test_get_submodules(dataset):
+    dataset.get('.', recursive=True, recursion_limit=1, get_data=False)
+
 def test_autoenable(dataset):
     siblings = dataset.siblings()
     sibling_names = [sib['name'] for sib in siblings]
@@ -46,8 +55,6 @@ def test_files_in_remote(dataset):
             '--in', public_sibling['name']]))
         assert len(sensitive_files_shared) == 0, f"Sensitive files mistakenly shared: \n{sensitive_files_shared}"
 
-def test_get_submodules(dataset):
-    dataset.get('.', recursive=True, recursion_limit=1, get_data=False)
 
 def get_public_siblings(dataset):
     siblings = dataset.siblings()


### PR DESCRIPTION
add tests to cover:
- https://github.com/datalad/datalad/issues/7604

see https://github.com/courtois-neuromod/cneuromod/pull/25 for dataset-level fix. 